### PR TITLE
メッセージ投稿機能の実装

### DIFF
--- a/app/assets/stylesheets/room.css
+++ b/app/assets/stylesheets/room.css
@@ -89,3 +89,8 @@ select {
   height: 80px;
   width: 100%;
 }
+
+.field_with_errors {
+  display: contents;
+  /* contentsを指定すると、その要素のボックスだけが表示されなくなります。 */
+}

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,26 @@
 class MessagesController < ApplicationController
   def index
+    @message = Message.new
+    @room = Room.find(params[:room_id])
+    # paramsにふくまれるroomのidを取得
   end
+
+  def create
+    @room = Room.find(params[:room_id])
+    @message = @room.messages.new(message_params)
+    # @room.messages.newでチャットルームに紐づいたメッセージのインスタンスを生成
+    # message_paramsを引数にして、privateメソッドを呼び出し
+    if @message.save
+    # 生成したインスタンスを@messageに代入し、saveメソッドでメッセージの内容をmessagesテーブルに保存
+      redirect_to  room_messages_path
+    else
+      render :index
+    end
+  end
+
+  private
+  def message_params
+    params.require(:message).permit(:content).merge(user_id: current_user.id)
+  end
+
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -3,6 +3,9 @@ class MessagesController < ApplicationController
     @message = Message.new
     @room = Room.find(params[:room_id])
     # paramsにふくまれるroomのidを取得
+    @messages = @room.messages.includes(:user)
+    # チャットルームに紐付いている全てのメッセージ（@room.messages）を@messagesと定義
+    # 全てのメッセージ情報に紐づくユーザー情報を、includes(:user)と記述をすることにより、ユーザー情報を1度のアクセスでまとめて取得することができます。
   end
 
   def create
@@ -14,6 +17,7 @@ class MessagesController < ApplicationController
     # 生成したインスタンスを@messageに代入し、saveメソッドでメッセージの内容をmessagesテーブルに保存
       redirect_to  room_messages_path
     else
+      @messages = @room.messages.includes(:user)
       render :index
     end
   end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -3,7 +3,7 @@ class RoomsController < ApplicationController
   def index
 
   end
-  
+
   def new 
     @room = Room.new
   end
@@ -17,6 +17,12 @@ class RoomsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def destroy
+    room = Room.find(params[:id])
+    room.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,4 @@
+class Message < ApplicationRecord
+  belongs_to :user
+  belongs_to :room
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,7 @@
 class Message < ApplicationRecord
   belongs_to :user
   belongs_to :room
+
+  validates :content, presence: true
+  
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,7 +1,7 @@
 class Room < ApplicationRecord
-  has_many :room_users
+  has_many :room_users, dependent: :destroy
   has_many :users, through: :room_users
-  has_many :messages
+  has_many :messages, dependent: :destroy
   
   validates :name, presence: true
   

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,7 +1,8 @@
 class Room < ApplicationRecord
   has_many :room_users
   has_many :users, through: :room_users
-
+  has_many :messages
+  
   validates :name, presence: true
   
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,9 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  validates :name, presence: true
-
   has_many :room_users
   has_many :rooms, through: :room_users
+  has_many :messages
+
+  validates :name, presence: true
 end

--- a/app/views/messages/_main_chat.html.erb
+++ b/app/views/messages/_main_chat.html.erb
@@ -2,7 +2,7 @@
 <div class="chat-header">
   <div class="left-header">
     <div class="header-title">
-    ヘンテコ
+    <%= @room.name %>
     </div>
   </div>
   <div class="right-header">

--- a/app/views/messages/_main_chat.html.erb
+++ b/app/views/messages/_main_chat.html.erb
@@ -14,37 +14,7 @@
 
 <%# メイン %>
 <div class="messages">
-  <div class="message">
-    <div class="upper-message">
-      <div class="message-user">
-        asuka
-      </div>
-      <div class="message-date">
-        2022/08/13
-      </div>
-    </div>
-    <div class="lower-message">
-      <div class="message-content">
-        おはよう
-      </div>
-    </div>
-  </div>
-
-  <div class="message">
-    <div class="upper-message">
-      <div class="message-user">
-        iori
-      </div>
-      <div class="message-date">
-        2022/08/13
-      </div>
-    </div>
-    <div class="lower-message">
-      <div class="message-content">
-        ヤッホー
-      </div>
-    </div>
-  </div>
+  <%= render partial: "message", collection: @messages%>
 </div>
 
 <%# フォーム %>

--- a/app/views/messages/_main_chat.html.erb
+++ b/app/views/messages/_main_chat.html.erb
@@ -48,13 +48,13 @@
 </div>
 
 <%# フォーム %>
-<div class="form">
+<%= form_with model: [@room, @message], class: "form", local: true do |f|%>
   <div class="form-input">
-    <input class="form-message" placefolder="type a message">
+    <%= f.text_field :content, class: "form-message", placeholder: "type message" %>
     <label class="form-image">
       <span class="image-file">画像</span>
-      <input type ="file" class="hidden">
+      <%= f.file_field :image, class: "hidden"%>
     </label>
   </div>
-  <input class="form-submit"type="submit" value="送信">
-</div>
+  <%= f.submit "送信", class: "form-submmit" %>
+<% end %>

--- a/app/views/messages/_main_chat.html.erb
+++ b/app/views/messages/_main_chat.html.erb
@@ -7,7 +7,7 @@
   </div>
   <div class="right-header">
     <div class="header-button">
-      <%= link_to "チャットを終了する", "#" %>
+      <%= link_to "チャットを終了する", room_path(@room), method: :delete %>
     </div>
   </div>
 </div>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -6,7 +6,7 @@
     </div>
     <div class="message-date">
       <!-- 投稿した時刻を出力する -->
-      <%= message.created_at %>
+      <%= l message.created_at %>
     </div>
   </div>
   <div class="lower-message">

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,0 +1,19 @@
+<div class="message">
+  <div class="upper-message">
+    <div class="message-user">
+    <!-- 投稿したユーザー名情報を出力する -->
+      <%= message.user.name %>
+    </div>
+    <div class="message-date">
+      <!-- 投稿した時刻を出力する -->
+      <%= message.created_at %>
+    </div>
+  </div>
+  <div class="lower-message">
+    <div class="message-content">
+      <!-- 投稿したメッセージ内容を記述する -->
+      <%= message.content %>
+    </div>
+  </div>
+</div>
+

--- a/app/views/messages/_side_bar.html.erb
+++ b/app/views/messages/_side_bar.html.erb
@@ -11,7 +11,7 @@
   <% current_user.rooms.each do |room| %>
     <div class="room">
       <div class="room-name">
-        <%= link_to room.name, "#" %>
+        <%= link_to room.name, room_messages_path(room) %>
       </div>
     </div>
   <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,8 @@ module ChitApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.i18n.default_locale = :ja
+    config.time_zone = "Tokyo"
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,4 @@
+ja:
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   get 'messages/index'
   root to: "rooms#index"
   resources :users, only: [:edit, :update]
-  resources :rooms, only: [:new, :create] do
+  resources :rooms, only: [:new, :create, :destroy] do
     resources :messages, only: [:index, :create]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,7 @@ Rails.application.routes.draw do
   get 'messages/index'
   root to: "rooms#index"
   resources :users, only: [:edit, :update]
-  resources :rooms, only: [:new, :create]
+  resources :rooms, only: [:new, :create] do
+    resources :messages, only: [:index, :create]
+  end
 end

--- a/db/migrate/20220819021918_create_messages.rb
+++ b/db/migrate/20220819021918_create_messages.rb
@@ -1,0 +1,10 @@
+class CreateMessages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :messages do |t|
+      t.string :content
+      t.references :user, null: false, foreign_key: true
+      t.references :room, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_18_033826) do
+ActiveRecord::Schema.define(version: 2022_08_19_021918) do
+
+  create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "content"
+    t.bigint "user_id", null: false
+    t.bigint "room_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["room_id"], name: "index_messages_on_room_id"
+    t.index ["user_id"], name: "index_messages_on_user_id"
+  end
 
   create_table "room_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "room_id", null: false
@@ -40,6 +50,8 @@ ActiveRecord::Schema.define(version: 2022_08_18_033826) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "messages", "rooms"
+  add_foreign_key "messages", "users"
   add_foreign_key "room_users", "rooms"
   add_foreign_key "room_users", "users"
 end


### PR DESCRIPTION
# WHAT
・テキストの投稿機能を実装。
・チャットルームとそれに紐づくメッセージを削除する機能を実装

# WHY
テキストの投稿機能を実装すること
投稿したテキストをメッセージ一覧画面に表示させること
投稿時刻を日本時刻へ変更すること
テキストが空の状態ではテキストを送れないようにバリデーションを設定すること
現在のチャットルーム名をメッセージ一覧画面のヘッダーに表示すること
チャットルーム削除機能を実装すること

